### PR TITLE
Question-and-Answer Rewrite

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,41 +1,92 @@
 <!doctype html>
 <html lang=en>
-	<head>
-		<meta charset=utf-8>
-		<title>Common Form</title>
-		<link rel=stylesheet href=html5-doctor-reset-stylesheet.min.css>
-		<link rel=stylesheet href='//fonts.googleapis.com/css?family=Alegreya+Sans:100,300,400,500,700,800,900,500italic,400italic,100italic,900italic,300italic,700italic,800italic&amp;subset=latin,latin-ext'>
-		<link rel=stylesheet href=styles.css>
-	</head>
-	<body>
-		<div class=container>
+  <head>
+    <meta charset=utf-8>
+    <title>Common Form</title>
+    <link rel=stylesheet href=html5-doctor-reset-stylesheet.min.css>
+    <link rel=stylesheet href='//fonts.googleapis.com/css?family=Alegreya+Sans:100,300,400,500,700,800,900,500italic,400italic,100italic,900italic,300italic,700italic,800italic&amp;subset=latin,latin-ext'>
+    <link rel=stylesheet href=styles.css>
+  </head>
+  <body>
+    <div class=container>
       <img class=logo src=logo.svg alt=logotype>
-			<h1>Common Form</h1>
-			<p class=subtitle>composable, verifiable, shareable legal contracts</p>
-      <p>
-        Common Form is a computer language for legal forms.
-        It allows software to express not just legal text, but the sections, references, definitions, and placeholders that give it structure.
-        Programs that speak Common Form can work together to solve problems word processors and document assemblers can’t.
+      <h1>Common Form</h1>
+
+      <p class=subtitle>shareable, verifiable, remixable form contracts</p>
+
+      <p class=question>
+        Can’t be sure if you’ve seen that NDA before without rereading?
       </p>
-      <p>
-        Both the language of Common Form and <a href='https://github.com/commonform'>computer code to use it</a> are licensed, free of charge, on <a href='http://apache.org/licenses/LICENSE-2.0'>highly permissive, professionally drafted open-source terms</a>.
-        The code is neatly divided into small building blocks that are easy to reuse in other projects.
+      <p class=answer>
+        <a href=https://commonform.org/forms/132a47018a4ae6524fb5fc21d407fc4476909cedbca0494da42e8ce1d5f780f7?introduce=fingerprint>Life’s too short</a>.
       </p>
-      <p>
-        <a href='https://github.com/orgs/commonform/people'>The Common Form team</a> has written some programs to show a bit of what’s possible.
-        You can see them working together at <a href=https://commonform.org>commonform.org</a>:
+
+      <p class=question>
+        Where’s the broken cross-reference in your 20-page draft?
       </p>
-      <ul>
-        <li><a href=https://commonform.org/forms/132a47018a4ae6524fb5fc21d407fc4476909cedbca0494da42e8ce1d5f780f7>Fill out a nondisclosure agreement and save to Word format.</a></li>
-        <li><a href=https://commonform.org/forms/4cc3bf2022996f5276ee732706644649fdf3a039edf9f80c67f2a6b3d91d7673>Review a standard venture finance instrument.</a></li>
-        <li><a href=https://commonform.org/forms/a47f5ca66c05fc2d0996a59d13044f7c46c12f00be82363d032d02a8a21cdb05>Skim a lengthy set of corporate bylaws.</a></li>
-      </ul>
-      <p>
-        Common Form is under active development.
-        The current focus is improving the <a href=https://github.com/commonform/commonform.org>browser interface</a>.
-        If you are adept at command-line computing, you can use the <a href=https://github.com/commonform/commonform-cli>command-line interface</a>.
-        If you'd like to contribute code, considering logging into GitHub and tackling an <a href="https://github.com/issues?utf8=%E2%9C%93&amp;q=is%3Aopen+is%3Aissue+user%3Acommonform+label%3A%22help+wanted%22">open issue</a>.
+      <p class=answer>
+        <a href=https://commonform.org/forms/X?introduce=errors>Look for the ⚠s.</a>
+        It checks defined terms, too.
       </p>
-		</div>
-	</body>
+
+      <p class=question>
+        Afraid to tweak because numbering and format will take hours?
+      </p>
+      <p class=answer>
+        <a href=https://commonform.org/forms/a47f5ca66c05fc2d0996a59d13044f7c46c12f00be82363d032d02a8a21cdb05?introduce=download>Not any more it doesn’t.</a>
+      </p>
+
+      <p class=question>
+        Want share forms online without disclosing confidences?
+      </p>
+      <p class=answer>
+        <a href=https://commonform.org/forms/X?introduce=sharing>That’s the point.</a> The rest is gravy.
+      </p>
+
+      <p class=question>
+        Using problematic, wordy, or archaic language?
+      </p>
+      <p class=answer>
+        The answer is “yes”.
+        <a href=https://commonform.org/forms/a47f5ca66c05fc2d0996a59d13044f7c46c12f00be82363d032d02a8a21cdb05?introduce=annotations>Common Form can help</a>.
+      </p>
+
+      <p class=question>
+        What does this technology cost?
+      </p>
+      <p class=answer>
+        <a href=http://apache.org/licenses/LICENSE-2.0>Here’s a free license</a>. And <a href=https://github.com/commonform>here's the code</a> while we’re at it.
+      </p>
+
+      <p class=question>
+        How can you use it?
+      </p>
+      <p class=answer>
+        <a href=https://edit.commonform.org>You can write forms using just your web browser.</a>
+      </p>
+
+      <p class=question>
+        Where can you get help?
+      </p>
+      <p class=answer>
+        <a href=https://github.com/join>Sign up for GitHub</a> and <a href=https://github.com/commonform/help/issues>create an issue here</a>.
+      </p>
+
+      <p class=question>
+        How can you help?
+      </p>
+      <p class=answer>
+        Write good forms and share them.<br>
+        Use the tools and tell us how to improve them.<br>
+        If you code, log into GitHub and tackle an <a href="https://github.com/issues?utf8=%E2%9C%93&amp;q=is%3Aopen+is%3Aissue+user%3Acommonform+label%3A%22help+wanted%22">open issue</a>.<br>
+      </p>
+
+      <p class=question>
+        Who’s behind all this?
+      </p>
+      <p class=answer>
+        <a href=https://github.com/orgs/commonform/people>Lawyers</a>.
+      </p>
+    </div>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -35,7 +35,7 @@ h2 {
 }
 
 p {
-  padding: 14px 0;
+  padding: 0.5rem 0;
   line-height: 140%;
   text-align: justify;
 }
@@ -63,4 +63,14 @@ ul {
 
 ul > li {
   margin: 7px 28px;
+}
+
+.question {
+  text-align: center;
+  padding-top: 2rem;
+}
+
+.answer {
+  text-align: center;
+  font-style: italic;
 }


### PR DESCRIPTION
@anseljh & @tbrooke:

I am rewriting https://commonform.github.io in a question-and-answer style, with demos showing the various practical ways Common Form can work for you. This is a work in progress. I'd like to collect thoughts and to-dos here.

First off the bat: Have either of your converted a form that you could share that ended up having a broken cross-reference buried somewhere? I'm sure I've seen that kind of thing, but can't remember where. I'd like to link to a form for a demonstration of the software picking out technical needle in a pretty big form haystack.

I am also working on adding "introduction" functionality to https://commonform.org so that links from https://commonform.github.io can highlight specific features, like fingerprints, annotations, the download button, &c., tutorial-style.
